### PR TITLE
fix typo in vdsat parameter reference

### DIFF
--- a/src/mosplot/lookup_table_generator/simulators/spice_simulators/ngspice_simulator.py
+++ b/src/mosplot/lookup_table_generator/simulators/spice_simulators/ngspice_simulator.py
@@ -67,7 +67,7 @@ class NgspiceSimulator(BaseSimulator):
             "id":     ["save i(vds)",             "i(i_vds)"],
             "weff":   [f"save @{symbol}[weff]",   f"v(@{symbol}[weff])"],
             "vth":    [f"save @{symbol}[vth]",    f"v(@{symbol}[vth])"],
-            "vdsat":  [f"save @{symbol}[vdsat]",  f"v(@{symbol}[vdsst])"],
+            "vdsat":  [f"save @{symbol}[vdsat]",  f"v(@{symbol}[vdsat])"],
             "vdssat": [f"save @{symbol}[vdssat]", f"v(@{symbol}[vdssat])"],
             "gm":     [f"save @{symbol}[gm]",     f"@{symbol}[gm]"],
             "gmbs":   [f"save @{symbol}[gmbs]",   f"@{symbol}[gmbs]"],


### PR DESCRIPTION
Fixed small typo that prevented vdsat to be saved into the lookup tables when using ngspice simulator.